### PR TITLE
Refactor build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ before_script:
   - bash ci.sh build
 
 script:
-  - bash ci.sh run
+  - bash ci.sh check4updates
 
 deploy:
   provider: script
-  script: bash ci.sh deploy
+  script: bash ci.sh push
   on:
     branch: master
     condition: $TRAVIS_EVENT_TYPE != cron
+    tags: true

--- a/ci.sh
+++ b/ci.sh
@@ -1,18 +1,35 @@
 #!/bin/bash
-readonly _TODAY=$(date +'%Y%m%d')
-readonly _TAG="$_TODAY"-"$TRAVIS_COMMIT"
+readonly _IMAGE="jorianvo/vue-ci"
+
+if command -v node >/dev/null 2>&1; then
+    _TAG=$(node vueVersion.js)
+else
+    _TAG="latest"
+fi
+
+function _run () {
+    docker run -v "$PWD:/site" -w "/site" "$_IMAGE":"$_TAG" $1
+}
 
 function build () {
-    docker build -t "$DOCKER_IMAGE":"$_TAG" .
+    docker build -t "$_IMAGE":"$_TAG" .
 }
 
-function run () {
-    docker run "$DOCKER_IMAGE":"$_TAG" npm run check4updates
+function check4updates () {
+    _run "npm run check4updates"
 }
 
-function deploy () {
+function upgrade () {
+    _run "npm run update"
+    _run "npm install"
+}
+
+function push () {
+    local TAG_MAJOR_PATCH=$(node vueVersion.js --short)
+
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    docker push "$DOCKER_IMAGE":"$_TAG"
+    docker push "$_IMAGE":"${_TAG}-b${TRAVIS_BUILD_NUMBER}"
+    docker push "$_IMAGE":"$TAG_MAJOR_PATCH"
 }
 
 case $1 in
@@ -20,12 +37,16 @@ case $1 in
         build
         ;;
     
-    run)
-        run
+    check4updates)
+        check4updates
         ;;
 
-    deploy)
-        deploy
+    upgrade)
+        upgrade
+        ;;
+
+    push)
+        push
         ;;
 
     *)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This project builds a docker container for use with Vue.js and Snyk in both a local and CI environment. ",
   "main": "index.js",
   "scripts": {
-    "check4updates": "ncu -e 2"
+    "check4updates": "ncu -e 2",
+    "update": "ncu -u"
   },
   "repository": {
     "type": "git",

--- a/vueVersion.js
+++ b/vueVersion.js
@@ -1,0 +1,9 @@
+const pjson = require('./package.json');
+const vueVersion = pjson.dependencies["@vue/cli"];
+
+if (process.argv[2] && process.argv[2] === '--short') {
+    const majorAndPatchVersion = vueVersion.match(/\d+\.\d+/g)[0];
+    console.log(majorAndPatchVersion);
+} else {
+    console.log(vueVersion);
+}


### PR DESCRIPTION
so now we can easily upgrade the packages locally using the 'upgrade' command. Update the push (previously deploy) logic so we now push two tags. The tags are based on the @vue-cli version, we push a full version (with unique build number) and a stable version (major.patch) for use in our CI systems.