### PR TITLE
Remove the requirement for a tag as currently we'll see if using the …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ deploy:
   on:
     branch: master
     condition: $TRAVIS_EVENT_TYPE != cron
-    tags: true


### PR DESCRIPTION
…Travis build number is sufficient