### PR TITLE
fix(workflows/*.yml): use a personal access token

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Branch build
     runs-on: ubuntu-latest
+    with:
+      token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      persist-credentials: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     name: Branch build
     runs-on: ubuntu-latest
-    with:
-      token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      persist-credentials: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: false
       - name: Build
         run: npm run build

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -12,11 +12,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: false
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           output-file: "false"
       - name: Build
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
@@ -26,7 +29,7 @@ jobs:
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: false
       - name: Set tag
         run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up Docker Buildx


### PR DESCRIPTION
instead of the default github token

When using the default github token, a new workflow run is never triggered to avoid the possibility
of recursive runs. I've switched to using a Personal Access Token and that should allow the publish
workflow to run